### PR TITLE
Fix setter in ExternalCatalogSetup

### DIFF
--- a/Editor/Build/DataBuilders/ExternalCatalogSetup.cs
+++ b/Editor/Build/DataBuilders/ExternalCatalogSetup.cs
@@ -43,7 +43,7 @@ namespace UnityEditor.AddressableAssets.Build.DataBuilders
 		public IReadOnlyList<AddressableAssetGroup> AssetGroups
 		{
 			get { return assetGroups; }
-			set { new List<AddressableAssetGroup>(value); }
+			set { assetGroups = new List<AddressableAssetGroup>(value); }
 		}
 
 		public bool IsPartOfCatalog(ContentCatalogDataEntry loc, AddressableAssetsBuildContext aaContext)


### PR DESCRIPTION
The `AssetGroups` setter in `ExternalCatalogSetup` was a no-op.