### PR TITLE
Fix error caused by a typo in Unity's code being fixed

### DIFF
--- a/Editor/GUI/AddressableAssetsSettingsGroupEditor.cs
+++ b/Editor/GUI/AddressableAssetsSettingsGroupEditor.cs
@@ -261,9 +261,9 @@ namespace UnityEditor.AddressableAssets.GUI
 			if (m_SearchStyles == null)
 			{
 				m_SearchStyles = new List<GUIStyle>();
-				m_SearchStyles.Add(GetStyle("ToolbarSearchTextFieldPopup", "ToolbarSeachTextFieldPopup")); //GetStyle("ToolbarSeachTextField");
-				m_SearchStyles.Add(GetStyle("ToolbarSearchCancelButton", "ToolbarSeachCancelButton"));
-				m_SearchStyles.Add(GetStyle("ToolbarSearchCancelButtonEmpty", "ToolbarSeachCancelButtonEmpty"));
+				m_SearchStyles.Add(GetStyle("ToolbarSearchTextFieldPopup", "ToolbarSearchTextFieldPopup")); //GetStyle("ToolbarSearchTextField");
+				m_SearchStyles.Add(GetStyle("ToolbarSearchCancelButton", "ToolbarSearchCancelButton"));
+				m_SearchStyles.Add(GetStyle("ToolbarSearchCancelButtonEmpty", "ToolbarSearchCancelButtonEmpty"));
 			}
 
 			if (m_ButtonStyle == null)

--- a/Editor/GUI/AddressableAssetsSettingsLabelMaskPopup.cs
+++ b/Editor/GUI/AddressableAssetsSettingsLabelMaskPopup.cs
@@ -59,9 +59,9 @@ namespace UnityEditor.AddressableAssets.GUI
             m_SearchField = new SearchField();
             m_ActivatorRect = activatorRect;
             m_SearchStyles = new List<GUIStyle>();
-            m_SearchStyles.Add(AddressablesGUIUtility.GetStyle("ToolbarSeachTextField"));
-            m_SearchStyles.Add(AddressablesGUIUtility.GetStyle("ToolbarSeachCancelButton"));
-            m_SearchStyles.Add(AddressablesGUIUtility.GetStyle("ToolbarSeachCancelButtonEmpty"));
+            m_SearchStyles.Add(AddressablesGUIUtility.GetStyle("ToolbarSearchTextField"));
+            m_SearchStyles.Add(AddressablesGUIUtility.GetStyle("ToolbarSearchCancelButton"));
+            m_SearchStyles.Add(AddressablesGUIUtility.GetStyle("ToolbarSearchCancelButtonEmpty"));
 
             m_HintLabelStyle = new GUIStyle(UnityEngine.GUI.skin.label);
             m_HintLabelStyle.fontSize = 10;


### PR DESCRIPTION
In an older version, Unity had some misspelled GUI styles that this code depended on. In current LTS versions, this spelling mistake is fixed, causing these exceptions:

`Missing built-in guistyle ToolbarSeachTextFieldPopup
UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&) (at /home/bokken/build/output/unity/unity/Modules/IMGUI/GUIUtility.cs:189)`
`Missing built-in guistyle ToolbarSeachCancelButton
UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&) (at /home/bokken/build/output/unity/unity/Modules/IMGUI/GUIUtility.cs:189)`
`Missing built-in guistyle ToolbarSeachCancelButtonEmpty
UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&) (at /home/bokken/build/output/unity/unity/Modules/IMGUI/GUIUtility.cs:189)`

This PR solves the issue by looking up GUI styles with the correct names.